### PR TITLE
Fix for the delay icon when Foundry is in a subfolder of the host

### DIFF
--- a/src/modules/delay/tracker.ts
+++ b/src/modules/delay/tracker.ts
@@ -30,7 +30,7 @@ function drawButton(type: "delay" | "return", combatentHtml: JQuery, combatant: 
 		const cls = MODULE.settings.allowReturn ? "initiative-return" : "initiative-delay-indicator"
 		button = $(`
       <div id="initiative-return" class="${cls}" title="${title}">
-        <img class="delay-indicator" src="/icons/svg/clockwork.svg"></img>
+        <img class="delay-indicator" src="icons/svg/clockwork.svg"></img>
         <i class="fa-solid fa-play"></i>
       </div>
     `)


### PR DESCRIPTION
The icon for the button to return to initiative from delay shows a broken image if the URL of the Foundry server is not at the root of the hostname.