### PR TITLE
Add missing english localization for other perception conditions

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -144,7 +144,9 @@
 					"blinded": "Blinded",
 					"concealed": "Concealed",
 					"dazzled": "Dazzled",
-					"hidden": "Hidden"
+					"hidden": "Hidden",
+          "undetected": "Undetected",
+          "unnoticed": "Unnoticed"
 				}
 			},
 			"message": {


### PR DESCRIPTION
Add missing english localization for other perception conditions unnoticed and undetected
even if it shouldn't happen and shouldn't be rolled in correct gameplay,  it might happen by mistake and currently prints the unlocalized name without this fix