### PR TITLE
Fix PF2e Toolbelt integration

### DIFF
--- a/src/modules/flat/message.ts
+++ b/src/modules/flat/message.ts
@@ -50,22 +50,6 @@ interface MsgFlagTargetCountData {
 	targetCount: number
 }
 
-type RollTrackerTool = {
-	addRoll: (roll: {
-		value: number
-		time: number
-		type: "flat-check"
-		isPrivate: boolean
-		isReroll: boolean
-		actor?: string
-		encounter?: string
-		session?: string
-		outcome?: "success" | "failure"
-		modifier?: string
-	}) => void
-	settings?: { session?: string }
-}
-
 export type MsgFlagData = Record<string, MsgFlagCheckData> & {
 	target?: MsgFlagCheckData | MsgFlagTargetCountData
 }
@@ -391,7 +375,7 @@ async function autoRoll(msg: ChatMessagePF2e) {
 			userId: game.user.id,
 			rolls: JSON.stringify([roll])
 		})
-    addRollToTracker(msg, check, roll.total, !!check?.reroll)
+    await addRollToTracker(msg, check, roll.total, !!check?.reroll)
 	}
 
 	return updates
@@ -432,14 +416,16 @@ interface SocketData {
 	rolls: string
 }
 
-function addRollToTracker(msg: ChatMessagePF2e, check: MsgFlagCheckData | undefined, roll: number, isReroll: boolean) {
+async function addRollToTracker(msg: ChatMessagePF2e, check: MsgFlagCheckData | undefined, roll: number, isReroll: boolean) {
 	// @ts-expect-error
-	const tool = game.toolbelt?.dev?.tools?.rollTracker as RollTrackerTool | undefined
-	if (!tool || !check) return
+	const toolBelt = game.toolbelt
+	if (!toolBelt || !check) return
 
 	const outcome = check.finalDc == null ? undefined : roll >= check.finalDc ? "success" : "failure"
 
-	tool.addRoll({
+	const currentData = game.settings.get("pf2e-toolbelt", "rollTracker.userRolls").slice()
+
+	currentData.push({
 		value: roll,
 		time: Date.now(),
 		type: "flat-check",
@@ -447,10 +433,12 @@ function addRollToTracker(msg: ChatMessagePF2e, check: MsgFlagCheckData | undefi
 		isReroll,
 		actor: msg.actor?.id,
 		encounter: game.combat?.id,
-		session: tool.settings?.session,
+		session: game.settings.get("pf2e-toolbelt", "rollTracker.session"),
 		outcome,
 		modifier: "flat",
 	})
+
+	await game.settings.set("pf2e-toolbelt", "rollTracker.userRolls", currentData)
 }
 
 function emitDiceSoNiceRoll(data: SocketData) {
@@ -531,7 +519,7 @@ async function handleFlatButtonClick(msg: ChatMessagePF2e, key: string, dc: numb
 			rolls: JSON.stringify([roll.toJSON()]),
 		})
 
-		addRollToTracker(msg, check, roll.total, !!oldRoll)
+		await addRollToTracker(msg, check, roll.total, !!oldRoll)
 
 		await msg.update(updates)
 

--- a/src/modules/flat/message.ts
+++ b/src/modules/flat/message.ts
@@ -421,6 +421,8 @@ async function addRollToTracker(msg: ChatMessagePF2e, check: MsgFlagCheckData | 
 	const toolBelt = game.toolbelt
 	if (!toolBelt || !check) return
 
+	if (!game.settings.get("pf2e-toolbelt", "rollTracker.enabled")) return
+
 	const outcome = check.finalDc == null ? undefined : roll >= check.finalDc ? "success" : "failure"
 
 	const currentData = game.settings.get("pf2e-toolbelt", "rollTracker.userRolls").slice()


### PR DESCRIPTION
It broke in the most recent version because I was relying on the dev API.

After a quick discussion with Idle I decided to simply push it directly to the setting where the data is stored.

This also happens to fix two minor issues I ran into:
- Rolls were still tracked if the tracker was disabled
- If multiple rolls happened in the same message and auto-roll was enabled one of the rolls could be dropped

Change should work with older Toolbelt versions as I don't depend on its API anymore (other than to check that Toolbelt module is enabled) and the setting is the same in both versions.