### PR TITLE
fix: prioritize getVisibilityFactors over plain getVisibility in AVS flat check

### DIFF
--- a/src/modules/flat/visioner.ts
+++ b/src/modules/flat/visioner.ts
@@ -48,12 +48,6 @@ export async function visionerAVSFlatCheck(
 	origin: TokenDocumentPF2e,
 	target: TokenDocumentPF2e,
 ): Promise<TargetFlatCheckSource | null> {
-	// Prefer the richer getVisibilityFactors() API first: it carries slugs/reasons
-	// (e.g. "dazzled", "darkness") that visionerVisibilityFlatCheck()'s plain
-	// getVisibility() state string cannot provide. Falling back to
-	// visionerVisibilityFlatCheck() first meant this origin/reason data was
-	// almost never used, since getVisibility() nearly always resolves to a
-	// valid state.
 	const factors: VisibilityFactors = await game.modules
 		.get("pf2e-visioner")
 		// @ts-expect-error

--- a/src/modules/flat/visioner.ts
+++ b/src/modules/flat/visioner.ts
@@ -48,28 +48,33 @@ export async function visionerAVSFlatCheck(
 	origin: TokenDocumentPF2e,
 	target: TokenDocumentPF2e,
 ): Promise<TargetFlatCheckSource | null> {
-	const visibilityCheck = visionerVisibilityFlatCheck(origin, target)
-	if (visibilityCheck) return visibilityCheck
-
+	// Prefer the richer getVisibilityFactors() API first: it carries slugs/reasons
+	// (e.g. "dazzled", "darkness") that visionerVisibilityFlatCheck()'s plain
+	// getVisibility() state string cannot provide. Falling back to
+	// visionerVisibilityFlatCheck() first meant this origin/reason data was
+	// almost never used, since getVisibility() nearly always resolves to a
+	// valid state.
 	const factors: VisibilityFactors = await game.modules
 		.get("pf2e-visioner")
 		// @ts-expect-error
 		?.api.getVisibilityFactors(origin.id, target.id)
 
-	if (!factors || factors.state === "observed") return null
+	if (factors && factors.state !== "observed") {
+		// Visoner slugs are an array. Use highest priority slugs as origin
+		const sourceSlug = R.firstBy(factors.slugs, [(s) => slugPriorities.get(s) ?? Infinity, "asc"])
 
-	// Visoner slugs are an array. Use highest priority slugs as origin
-	const sourceSlug = R.firstBy(factors.slugs, [(s) => slugPriorities.get(s) ?? Infinity, "asc"])
+		const source: TargetFlatCheckSource = {
+			type: factors.state,
+		}
+		if (sourceSlug) {
+			source.origin = { slug: sourceSlug }
+			if (factors.reasons?.length) source.origin.reasons = factors.reasons
+		}
 
-	const source: TargetFlatCheckSource = {
-		type: factors.state,
+		return source
 	}
-	if (sourceSlug) {
-		source.origin = { slug: sourceSlug }
-		if (factors.reasons?.length) source.origin.reasons = factors.reasons
-	}
 
-	return source
+	return visionerVisibilityFlatCheck(origin, target)
 }
 
 export function visionerVisibilityFlatCheck(


### PR DESCRIPTION
## Summary
- `visionerAVSFlatCheck` called `visionerVisibilityFlatCheck` (which uses pf2e-visioner's plain `getVisibility()`) first and returned early whenever it got a non-null state — which is almost always the case, since most concealed/hidden/undetected states resolve to a valid `TargetConditionToDC` key.
- This meant the later `getVisibilityFactors()` call — which carries the richer `slugs`/`reasons` data (e.g. `dazzled`, `darkness`, `invisible`) — was effectively dead code, and the flat check DC badge never showed an origin suffix like "(Dazzled)" even when AVS integration was active and the reason was available.
- Swapped the order: `getVisibilityFactors()` is tried first, and `visionerVisibilityFlatCheck()` is only used as a fallback when factors are unavailable or `state === "observed"`.

## Test plan
- [x] `npx tsc --noEmit` — no new errors introduced (pre-existing unrelated errors in node_modules type-import config and `target-marker.ts` remain, `visioner.ts` itself is clean)
- [x] `vite build` completes successfully
- [x] Manual: with pf2e-visioner AVS enabled, hover/target a dazzled observer over a target and confirm the flat check DC badge shows the "(Dazzled)" origin